### PR TITLE
Add Yama boss example

### DIFF
--- a/sample/SampleRegion.ts
+++ b/sample/SampleRegion.ts
@@ -23,8 +23,8 @@ import {
   TorvaPlatelegs,
   TwistedBow,
   UltorRing,
+  Yama,
 } from "../src";
-import { SampleNpc } from "./SampleNpc";
 
 export class SampleRegion extends Region {
   get initialFacing() {
@@ -96,7 +96,7 @@ export class SampleRegion extends Region {
     };
     player.setUnitOptions(loadout);
 
-    this.addMob(new SampleNpc(this, { x: 25, y: 20 }, {}));
+    this.addMob(new Yama(this, { x: 25, y: 20 }, {}));
     return { player };
   }
 }

--- a/src/content/bosses/Yama.ts
+++ b/src/content/bosses/Yama.ts
@@ -1,0 +1,75 @@
+import { Mob } from "../../sdk/Mob";
+import { MeleeWeapon } from "../../sdk/weapons/MeleeWeapon";
+import { GLTFModel } from "../../sdk/rendering/GLTFModel";
+import { Assets } from "../../sdk/utils/Assets";
+
+export class Yama extends Mob {
+  override mobName() {
+    return "Yama";
+  }
+
+  override get combatLevel() {
+    return 1000;
+  }
+
+  override setStats() {
+    this.weapons = {
+      crush: new MeleeWeapon(),
+    };
+
+    this.stats = {
+      attack: 150,
+      strength: 150,
+      defence: 150,
+      range: 150,
+      magic: 150,
+      hitpoint: 500,
+    };
+    this.currentStats = JSON.parse(JSON.stringify(this.stats));
+  }
+
+  override get bonuses() {
+    return {
+      attack: {
+        stab: 0,
+        slash: 0,
+        crush: 100,
+        magic: 0,
+        range: 0,
+      },
+      defence: {
+        stab: 100,
+        slash: 100,
+        crush: 100,
+        magic: 100,
+        range: 100,
+      },
+      other: {
+        meleeStrength: 50,
+        rangedStrength: 0,
+        magicDamage: 0,
+        prayer: 0,
+      },
+    };
+  }
+
+  override get attackSpeed() {
+    return 4;
+  }
+
+  attackStyleForNewAttack() {
+    return "crush";
+  }
+
+  get attackRange() {
+    return 1;
+  }
+
+  get size() {
+    return 5;
+  }
+
+  create3dModel() {
+    return GLTFModel.forRenderable(this, Assets.getAssetUrl("models/yama.glb"));
+  }
+}

--- a/src/content/bosses/index.ts
+++ b/src/content/bosses/index.ts
@@ -1,0 +1,2 @@
+// generated using Generate Index https://marketplace.visualstudio.com/items?itemName=JayFong.generate-index
+export { Yama } from './Yama';

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -4,3 +4,4 @@ export { InvisibleMovementBlocker } from "./MovementBlocker";
 export * from "./equipment";
 export * from "./items";
 export * from "./weapons";
+export * from "./bosses";

--- a/src/sdk/EntityName.ts
+++ b/src/sdk/EntityName.ts
@@ -18,4 +18,5 @@ export enum EntityNames {
   JAL_AK = "Jal-Ak",
   PILLAR = "Pillar",
   SOL_HEREDIT = "Sol Heredit",
+  YAMA = "Yama",
 }


### PR DESCRIPTION
## Summary
- add `YAMA` entry to `EntityNames`
- implement `Yama` boss and export from content
- export bosses from content package
- spawn Yama in the SampleRegion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68465cb1307c8323b6c80dcf1d674e80